### PR TITLE
sndsw: need to set FAIRROOTPATH CMake variable

### DIFF
--- a/sndsw.sh
+++ b/sndsw.sh
@@ -95,6 +95,7 @@ rsync -a $SOURCEDIR/ $INSTALLROOT/
 
 cmake $SOURCEDIR                                                 \
       -DFAIRBASE="$FAIRROOT_ROOT/share/fairbase"                 \
+      -DFAIRROOTPATH="$FAIRROOTPATH"                             \
       -DFAIRROOT_INCLUDE_DIR="$FAIRROOT_ROOT/include"            \
       -DFAIRROOT_LIBRARY_DIR="$FAIRROOT_ROOT/lib"                \
       -DFAIRLOGGER_INCLUDE_DIR="$FAIRLOGGER_ROOT/include"        \


### PR DESCRIPTION
Apparently the environment variable is not sufficient.