### PR TITLE
sndsw: googletest is not a dependency

### DIFF
--- a/defaults-release.sh
+++ b/defaults-release.sh
@@ -317,17 +317,6 @@ overrides:
       ls $GEANT3_ROOT/include/TGeant3/TGeant3.h > /dev/null && \
       ls $GEANT3_ROOT/lib64/libgeant321.so > /dev/null && \
       true
-  googletest:
-    prefer_system_check: |
-      ls $GOOGLETEST_ROOT/ > /dev/null && \
-      ls $GOOGLETEST_ROOT/include > /dev/null && \
-      ls $GOOGLETEST_ROOT/include/gmock > /dev/null && \
-      ls $GOOGLETEST_ROOT/include/gtest > /dev/null && \
-      ls $GOOGLETEST_ROOT/lib/libgmock.a > /dev/null && \
-      ls $GOOGLETEST_ROOT/lib/libgmock_main.a > /dev/null && \
-      ls $GOOGLETEST_ROOT/lib/libgtest.a > /dev/null && \
-      ls $GOOGLETEST_ROOT/lib/libgtest_main.a > /dev/null && \
-      true
   fedra:
     tag: rev1523
     prefer_system_check: |

--- a/sndsw.sh
+++ b/sndsw.sh
@@ -16,8 +16,6 @@ requires:
   - alpaca
   - FEDRA
   - XRootD
-build_requires:
-  - googletest
 incremental_recipe: |
   rsync -ar $SOURCEDIR/ $INSTALLROOT/
   make ${JOBS:+-j$JOBS}


### PR DESCRIPTION
It's used nowhere in sndsw and also not during the build.

We could also consider removing the recipe completely, as no package used by sndsw depends on it (only `messagepack` and `parquet-cpp` do).

