### PR TITLE
SNDstyle: Add recipe

### DIFF
--- a/sndstyle.sh
+++ b/sndstyle.sh
@@ -1,0 +1,26 @@
+package: SNDstyle
+version: main
+source: https://github.com/SND-LHC/SNDstyle
+requires:
+ - ROOT
+prepend_path:
+  PYTHONPATH: "$SNDSTYLE_ROOT"
+---
+#!/bin/bash
+
+cd $SOURCEDIR
+
+cp SNDstyle.py "$INSTALLROOT/"
+
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+
+alibuild-generate-module > $MODULEFILE
+
+cat >> "$MODULEFILE" <<EoF
+# Our environment
+set SNDSTYLE_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path PYTHONPATH \$SNDSTYLE_ROOT
+EoF


### PR DESCRIPTION
Add a recipe to install @dcentanni's [SNDstyle](https://github.com/SND-LHC/SNDstyle) to make nice looking plots using ROOT (as in many presentations).

For now, it need to be explicitly instlled using `aliBuild build SNDstyle -c snddist [...]`, but we could consider making it a dependency of sndsw to pull it in automatically.