### PR TITLE
Updating include paths and FEDRA repository

### DIFF
--- a/defaults-release.sh
+++ b/defaults-release.sh
@@ -318,7 +318,6 @@ overrides:
       ls $GEANT3_ROOT/lib64/libgeant321.so > /dev/null && \
       true
   fedra:
-    tag: rev1523
     prefer_system_check: |
       ls $FEDRA_ROOT/bin > /dev/null && \
       ls $FEDRA_ROOT/lib > /dev/null && \

--- a/fedra.sh
+++ b/fedra.sh
@@ -1,8 +1,8 @@
 package: FEDRA
-version: rev1523
-tag: rev1523
+version: rev1530
+tag: rev1530
 
-source: https://github.com/antonioiuliano2/fedra
+source: https://github.com/SND-LHC/fedra
 
 requires:
   - GCC-Toolchain

--- a/sndsw.sh
+++ b/sndsw.sh
@@ -78,6 +78,12 @@ incremental_recipe: |
   # required for ubuntu22.04: don't know how to fix this more elegant
   append-path PYTHONPATH        \$::env(XROOTD_ROOT)/local/lib/python3.10/dist-packages
 
+  append-path ROOT_INCLUDE_PATH \$::env(FEDRA_ROOT)/include
+  append-path ROOT_INCLUDE_PATH \$::env(FEDRA_ROOT)/include/smatrix
+  append-path ROOT_INCLUDE_PATH \$::env(FEDRA_ROOT)/include/vt++
+  append-path ROOT_INCLUDE_PATH \$::env(FEDRA_ROOT)/include/dataIO
+  append-path PYTHONPATH \$::env(FEDRA_ROOT)/python
+
   prepend-path PYTHONPATH \$::env(SNDSW_ROOT)/python
   append-path PYTHONPATH \$::env(SNDSW_ROOT)/shipLHC/scripts
   append-path PYTHONPATH \$::env(SNDSW_ROOT)/shipLHC/rawData
@@ -196,6 +202,12 @@ append-path PYTHONPATH \$::env(SNDSW_ROOT)/shipLHC/rawData
 append-path PYTHONPATH \$::env(XROOTD_ROOT)/lib/python/site-packages
 # required for ubuntu22.04: don't know how to fix this more elegant
 append-path PYTHONPATH  \$::env(XROOTD_ROOT)/local/lib/python3.10/dist-packages
+
+append-path ROOT_INCLUDE_PATH \$::env(FEDRA_ROOT)/include
+append-path ROOT_INCLUDE_PATH \$::env(FEDRA_ROOT)/include/smatrix
+append-path ROOT_INCLUDE_PATH \$::env(FEDRA_ROOT)/include/vt++
+append-path ROOT_INCLUDE_PATH \$::env(FEDRA_ROOT)/include/dataIO
+append-path PYTHONPATH \$::env(FEDRA_ROOT)/python
 
 $([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(SNDSW_ROOT)/lib")
 EoF


### PR DESCRIPTION
Dear all,

Following advice received by @ThomasRuf, I am updating the build information to append the include paths, since the compiler could not find the FEDRA libraries from the CVMFS environment.

I have also updated the repository to the SNDLHC one (instead of my private one), and update the GIT tag number to match the latest SVN revision.

I am available for any comment or question.

Best Regards,
Antonio Iuliano