### PR TITLE
sndsw: let alibuild figure out dependencies

### DIFF
--- a/sndsw.sh
+++ b/sndsw.sh
@@ -24,8 +24,8 @@ incremental_recipe: |
   rsync -a $BUILDDIR/bin $INSTALLROOT/
   # to be sure all header files are there
   rsync -a $INSTALLROOT/*/*.h $INSTALLROOT/include
-  rsync -a $INSTALLROOT/genfit/core/include/*.h $INSTALLROOT/include
-  #Get the current git hash
+  mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete $BUILDDIR/etc/modulefiles/ $INSTALLROOT/etc/modulefiles
+  #Get the current git hash and update modulefile
   cd $SOURCEDIR
   SNDSW_HASH=$(git rev-parse HEAD)
   sed -i -e "s/SNDSW_HASH .*/SNDSW_HASH $SNDSW_HASH/" "$INSTALLROOT/etc/modulefiles/sndsw"
@@ -93,7 +93,7 @@ SNDSW_HASH=$(git rev-parse HEAD)
 cd $BUILDDIR
 
 # Modulefile
-MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEDIR="$BUILDDIR/etc/modulefiles"
 MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
 
@@ -130,3 +130,5 @@ append-path PYTHONPATH  \$::env(XROOTD_ROOT)/local/lib/python3.10/dist-packages
 
 $([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(SNDSW_ROOT)/lib")
 EoF
+
+mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete $BUILDDIR/etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/sndsw.sh
+++ b/sndsw.sh
@@ -28,67 +28,7 @@ incremental_recipe: |
   #Get the current git hash
   cd $SOURCEDIR
   SNDSW_HASH=$(git rev-parse HEAD)
-  cd $BUILDDIR
-  # Modulefile
-  MODULEDIR="$INSTALLROOT/etc/modulefiles"
-  MODULEFILE="$MODULEDIR/$PKGNAME"
-  mkdir -p "$MODULEDIR"
-  cat > "$MODULEFILE" <<EoF
-  #%Module1.0
-  proc ModulesHelp { } {
-    global version
-    puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-  }
-  set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-  module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-  # Dependencies
-  module load BASE/1.0                                                          \\
-            ${XROOTD_VERSION:+XRootD/$XROOTD_VERSION-$XROOTD_REVISION}          \\
-            ${GEANT4_VERSION:+GEANT4/$GEANT4_VERSION-$GEANT4_REVISION}          \\
-            ${GENIE_VERSION:+GENIE/$GENIE_VERSION-$GENIE_REVISION}              \\
-            ${PHOTOSPP_VERSION:+PHOTOSPP/$PHOTOSPP_VERSION-$PHOTOSPP_REVISION}  \\
-            ${EVTGEN_VERSION:+EvtGen/$EVTGEN_VERSION-$EVTGEN_REVISION}          \\
-            ${FAIRROOT_VERSION:+FairRoot/$FAIRROOT_VERSION-$FAIRROOT_REVISION}  \\
-            ${MADGRAPH5_VERSION:+madgraph5/$MADGRAPH5_VERSION-$MADGRAPH5_REVISION} \\
-            ${ALPACA_VERSION:+alpaca/$ALPACA_VERSION-$ALPACA_REVISION}          \\
-            ${FEDRA_VERSION:+FEDRA/$FEDRA_VERSION-$FEDRA_REVISION}
-  # Our environment
-  setenv EOSSHIP root://eospublic.cern.ch/
-  setenv SNDSW_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-  setenv FAIRSHIP \$::env(SNDSW_ROOT)
-  setenv FAIRSHIP_ROOT \$::env(SNDSW_ROOT)
-  setenv SNDSW_HASH $SNDSW_HASH
-  setenv FAIRSHIP_HASH \$::env(SNDSW_HASH)
-  setenv VMCWORKDIR \$::env(SNDSW_ROOT)
-  setenv GEOMPATH \$::env(SNDSW_ROOT)/geometry
-  setenv CONFIG_DIR \$::env(SNDSW_ROOT)/gconfig
-  setenv GALGCONF \$::env(SNDSW_ROOT)/shipgen/genie_config
-  prepend-path PATH \$::env(SNDSW_ROOT)/bin
-  prepend-path LD_LIBRARY_PATH \$::env(SNDSW_ROOT)/lib
-  setenv FAIRLIBDIR \$::env(SNDSW_ROOT)/lib
-  prepend-path ROOT_INCLUDE_PATH \$::env(SNDSW_ROOT)/include
-  append-path ROOT_INCLUDE_PATH \$::env(GEANT4_ROOT)/include
-  append-path ROOT_INCLUDE_PATH \$::env(GEANT4_ROOT)/include/Geant4
-  append-path ROOT_INCLUDE_PATH \$::env(PYTHIA_ROOT)/include
-  append-path ROOT_INCLUDE_PATH \$::env(PYTHIA_ROOT)/include/Pythia8
-  append-path ROOT_INCLUDE_PATH \$::env(GEANT4_VMC_ROOT)/include
-  append-path ROOT_INCLUDE_PATH \$::env(GEANT4_VMC_ROOT)/include/geant4vmc
-  append-path ROOT_INCLUDE_PATH \$::env(SNDSW_ROOT)/genfit/core/include
-  append-path PYTHONPATH        \$::env(XROOTD_ROOT)/lib/python/site-packages
-  # required for ubuntu22.04: don't know how to fix this more elegant
-  append-path PYTHONPATH        \$::env(XROOTD_ROOT)/local/lib/python3.10/dist-packages
-
-  append-path ROOT_INCLUDE_PATH \$::env(FEDRA_ROOT)/include
-  append-path ROOT_INCLUDE_PATH \$::env(FEDRA_ROOT)/include/smatrix
-  append-path ROOT_INCLUDE_PATH \$::env(FEDRA_ROOT)/include/vt++
-  append-path ROOT_INCLUDE_PATH \$::env(FEDRA_ROOT)/include/dataIO
-  append-path PYTHONPATH \$::env(FEDRA_ROOT)/python
-
-  prepend-path PYTHONPATH \$::env(SNDSW_ROOT)/python
-  append-path PYTHONPATH \$::env(SNDSW_ROOT)/shipLHC/scripts
-  append-path PYTHONPATH \$::env(SNDSW_ROOT)/shipLHC/rawData
-  $([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(SNDSW_ROOT)/lib")
-  EoF
+  sed -i -e "s/SNDSW_HASH .*/SNDSW_HASH $SNDSW_HASH/" "$INSTALLROOT/etc/modulefiles/sndsw"
 ---
 #!/bin/sh
 
@@ -156,25 +96,10 @@ cd $BUILDDIR
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
 MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0                                                            \\
-            ${XROOTD_VERSION:+XRootD/$XROOTD_VERSION-$XROOTD_REVISION}          \\
-            ${GEANT4_VERSION:+GEANT4/$GEANT4_VERSION-$GEANT4_REVISION}          \\
-            ${GENIE_VERSION:+GENIE/$GENIE_VERSION-$GENIE_REVISION}              \\
-            ${PHOTOSPP_VERSION:+PHOTOSPP/$PHOTOSPP_VERSION-$PHOTOSPP_REVISION}  \\
-            ${EVTGEN_VERSION:+EvtGen/$EVTGEN_VERSION-$EVTGEN_REVISION}          \\
-            ${FAIRROOT_VERSION:+FairRoot/$FAIRROOT_VERSION-$FAIRROOT_REVISION}	\\
-            ${MADGRAPH5_VERSION:+madgraph5/$MADGRAPH5_VERSION-$MADGRAPH5_REVISION} \\
-            ${ALPACA_VERSION:+alpaca/$ALPACA_VERSION-$ALPACA_REVISION}          \\
-            ${FEDRA_VERSION:+FEDRA/$FEDRA_VERSION-$FEDRA_REVISION}
+
+alibuild-generate-module --bin --lib > $MODULEFILE
+
+cat >> "$MODULEFILE" <<EoF
 # Our environment
 setenv EOSSHIP root://eospublic.cern.ch/
 setenv SNDSW_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
@@ -202,12 +127,6 @@ append-path PYTHONPATH \$::env(SNDSW_ROOT)/shipLHC/rawData
 append-path PYTHONPATH \$::env(XROOTD_ROOT)/lib/python/site-packages
 # required for ubuntu22.04: don't know how to fix this more elegant
 append-path PYTHONPATH  \$::env(XROOTD_ROOT)/local/lib/python3.10/dist-packages
-
-append-path ROOT_INCLUDE_PATH \$::env(FEDRA_ROOT)/include
-append-path ROOT_INCLUDE_PATH \$::env(FEDRA_ROOT)/include/smatrix
-append-path ROOT_INCLUDE_PATH \$::env(FEDRA_ROOT)/include/vt++
-append-path ROOT_INCLUDE_PATH \$::env(FEDRA_ROOT)/include/dataIO
-append-path PYTHONPATH \$::env(FEDRA_ROOT)/python
 
 $([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(SNDSW_ROOT)/lib")
 EoF


### PR DESCRIPTION
If we specify the dependencies manually, we prevent aliBuild from loading the correct dependencies (e.g. when adding a new one).

We also overwrite the module file in the incremental build recipe.

This PR fixes both of those issues by using alibuild's builtin tool for generating modules automatically and by only updating the SNDSW_HASH when doing an incremental rebuild of sndsw.