### PR TITLE
zeromq: fix system check

### DIFF
--- a/zeromq.sh
+++ b/zeromq.sh
@@ -5,9 +5,10 @@ requires:
   - "GCC-Toolchain:(?!osx)"
 build_requires:
   - autotools
-prefer_system: (?!slc5.*)
+prefer_system: (.*)
 prefer_system_check: |
-  printf "#include <zmq.h>\n#if(ZMQ_VERSION < 40103)\n#error \"zmq version >= 4.1.3 needed\"\n#endif\n int main(){}" | gcc -I$(brew --prefix zeromq)/include $([[ -d $(brew --prefix zeromq) ]] || echo "-l:libzmq.a") -xc++ - -o /dev/null 2>&1
+  ZMQ_VERSION=${REQUESTED_VERSION//./0}
+  printf "#include <zmq.h>\n#if(ZMQ_VERSION < ${ZMQ_VERSION//v/})\n#error \"zmq version >= $REQUESTED_VERSION needed\"\n#endif\n int main(){}" | c++ -I$(brew --prefix zeromq)/include -xc++ - -o /dev/null 2>&1
 ---
 #!/bin/sh
 


### PR DESCRIPTION
The requested static library is not found. Removing that check seems to pick up system zeromq just fine.

Removed the conditional on slc5 while editing the recipe, as it's a platform we never supported.