### PR TITLE
Don't build FEDRA as dependency of sndsw (because it isn't one)

### DIFF
--- a/sndsw.sh
+++ b/sndsw.sh
@@ -14,7 +14,6 @@ requires:
   - ROOT
   - VMC
   - alpaca
-  - FEDRA
   - XRootD
 incremental_recipe: |
   rsync -ar $SOURCEDIR/ $INSTALLROOT/


### PR DESCRIPTION
As discussed the other day:

* FEDRA headers can cause issues due to conflicts with other headers, e.g. those of Genfit
* Nothing in sndsw currently depends on FEDRA
* Nobody using FEDRA currently builds it using snddist, and nobody uses the version built as part of the sndsw build.

FOr those that want to build FEDRA using snddist, it's as easy as running

`aliBuild build FEDRA -c snddist --default release`
